### PR TITLE
fix memory leak from iterator op

### DIFF
--- a/libs/trainer/trainer_utils.py
+++ b/libs/trainer/trainer_utils.py
@@ -1,18 +1,25 @@
 """Utilities for trainer."""
 from komorebi.libs.utilities.array_utils import partition_indices
 
-def get_dataset_iterator_for_epoch(dataset, sess):
-    """Get iterator for epoch training.
+def get_data_stream_for_epoch(dataset, sess):
+    """Get data stream for epoch training.
 
-    Shuffle dataset examples and return corresponding new iterator to shuffled examples.
+    Shuffle dataset examples and return corresponding tf iterator op to shuffled examples.
+
+    Note we return the iterator op rather than the iterator because each call to get_next()
+    adds an additional op on the tensorflow graph. Returning the op, calls the operation
+    only once per epoch.
     
     :param dataset: tf_dataset_wrapper object
     :param sess: tensorflow session
+    :return: tensorflow op for streamining data
     """
     shuffled_examples = dataset.get_shuffled_training_files()
     sess.run(dataset.iterator.initializer, 
              feed_dict={dataset.input_examples_op: shuffled_examples})
-    return dataset.iterator
+    shuffled_iterator = dataset.iterator
+    data_stream_op = shuffled_iterator.get_next()
+    return data_stream_op
 
 
 def compute_number_of_batches(dataset, batch_size):


### PR DESCRIPTION
This fixes the memory leak error caused by creating too many iterator ops. See https://stackoverflow.com/questions/47499138/iterator-get-next-cause-terminate-called-after-throwing-an-instance-of-stds