### PR TITLE
Fix incorrect sequence encoding in validation points

### DIFF
--- a/libs/evaluation/metrics.py
+++ b/libs/evaluation/metrics.py
@@ -105,6 +105,6 @@ def _compute_cross_entropy(inference_set):
     :param inference_set: set of validation points to evaluate
     :return: cross-entropy loss
     """
-    probabilities, labels = zip(*[(vp.probability_prediction[0], vp.label[0]) for vp in inference_set.validation_points])
+    probabilities, labels = zip(*[(vp.probability_prediction, vp.label) for vp in inference_set.validation_points])
     return sklearn.metrics.log_loss(y_true=labels, y_pred=probabilities)
 

--- a/libs/evaluation/model_scoring_utils.py
+++ b/libs/evaluation/model_scoring_utils.py
@@ -78,12 +78,19 @@ def _convert_example_to_single_task_validation_point(task_id, model, training_ex
             feed_dict={model.inputs['sequence']: training_example['sequence'],
                        model.inputs['features']: training_example['annotation']})
 
-    return validation_point(classification=np.ravel(classification),
-                            probability_prediction=np.ravel(probability),
-                            label=np.ravel(single_task_label),
+    # convert to correct dimensions
+    sequence = np.squeeze(training_example['sequence'])
+    context_probabilities = np.squeeze(context_probabilities)
+    probability = probability.item()
+    classification = classification.item()
+    single_task_label = single_task_label.item()
+    
+    return validation_point(classification=classification,
+                            probability_prediction=probability,
+                            label=single_task_label,
                             attention_result_instance=attention_result(
-                                sequence=np.ravel(training_example['sequence']),
-                                context_probabilities=np.ravel(context_probabilities)))
+                                sequence=sequence,
+                                context_probabilities=context_probabilities))
 
 
 def _convert_example_to_multitask_validation_point(model, training_example, sess):
@@ -98,9 +105,9 @@ def _convert_example_to_multitask_validation_point(model, training_example, sess
             feed_dict={model.inputs['sequence']: training_example['sequence'],
                        model.inputs['features']: training_example['annotation']})
     
-    # convert to 1-D arrays
-    probabilities = np.ravel(probabilities)
-    classifications = np.ravel(classification)
+    # convert to correct dimensions 
+    probabilities = np.squeeze(probabilities)
+    classification = np.squeeze(classification)
     labels = np.ravel(training_example['label'])
     
     return multitask_validation_point(

--- a/libs/utilities/constants.py
+++ b/libs/utilities/constants.py
@@ -8,3 +8,7 @@ SINGLE_PREDICTION = 1
 
 # numerical index to string nucleotide map 
 INDEX_TO_NUCLEOTIDE_MAP = {0: 'a', 1: 'c', 2: 'g', 3: 't'}
+
+# Offsets for context probability indexing
+SEQUENCE_OFFSET_LEFT = 6
+SEQUENCE_OFFSET_RIGHT = 7


### PR DESCRIPTION
This fix a crucial error in which sequences in validation point construction were incorrectly encoded. In this problem, all sequences stored in attention results only had characters "a", "c", rather than all ["a", "c", "g", "t"]. The problem turned out to be an incorrect use of `np.ravel()` when constructing validation points.