### PR TITLE
Fix misinterpretation of conv layer in motif extraction

### DIFF
--- a/libs/evaluation/metric_types.py
+++ b/libs/evaluation/metric_types.py
@@ -23,7 +23,7 @@ class attention_result(object):
 
     def _get_motif_and_score_from_context_index(self, index):
         """Retrieve motif and scor associated with context index."""
-        trace = convert_context_index_to_sequence_trace(index)
+        trace = _convert_context_index_to_sequence_trace(index)
         score = self.context_probabilities[index]
         motif = self.sequence_string[trace.start:trace.end]
         return motif, score

--- a/libs/utilities/constants.py
+++ b/libs/utilities/constants.py
@@ -9,6 +9,11 @@ SINGLE_PREDICTION = 1
 # numerical index to string nucleotide map 
 INDEX_TO_NUCLEOTIDE_MAP = {0: 'a', 1: 'c', 2: 'g', 3: 't'}
 
-# Offsets for context probability indexing
-SEQUENCE_OFFSET_LEFT = 6
-SEQUENCE_OFFSET_RIGHT = 7
+# DANQ constants
+DANQ_SEQUENCE_LENGTH = 1000
+DANQ_CONV1_STRIDE = 1
+DANQ_CONV1_KERNEL_SIZE = 26
+DANQ_POOL1_SIZE = 13
+DANQ_POOL1_STRIDE = 13
+
+


### PR DESCRIPTION
This fixes a previous error in the interpretation of context probabilities as they relate to indexing back to the original sequence.